### PR TITLE
feat(auth): 리프레시 토큰 재발급 API 추가

### DIFF
--- a/syncfit-auth-service/src/main/java/com/syncfitauthservice/controller/AuthController.java
+++ b/syncfit-auth-service/src/main/java/com/syncfitauthservice/controller/AuthController.java
@@ -1,11 +1,10 @@
 package com.syncfitauthservice.controller;
 
 import com.syncfitauthservice.dto.request.AuthCodeRequest;
+import com.syncfitauthservice.dto.request.RefreshTokenRequest;
 import com.syncfitauthservice.dto.response.SocialLoginResponse;
 import com.syncfitauthservice.service.AuthService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,12 +18,12 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/social-login")
-    public ResponseEntity<SocialLoginResponse> memberSocialLogin(@RequestBody AuthCodeRequest request) {
-        SocialLoginResponse response = authService.socialLoginMember(request);
+    public SocialLoginResponse memberSocialLogin(@RequestBody AuthCodeRequest request) {
+        return authService.socialLoginMember(request);
+    }
 
-//        String refreshToken = response.refreshToken();
-//        HttpHeaders headers = cookieUtil.generateRefreshTokenCookie(refreshToken);
-
-        return ResponseEntity.ok().body(response);
+    @PostMapping("/refresh")
+    public SocialLoginResponse refreshToken(@RequestBody RefreshTokenRequest request){
+        return authService.refreshToken(request);
     }
 }

--- a/syncfit-auth-service/src/main/java/com/syncfitauthservice/dto/request/RefreshTokenRequest.java
+++ b/syncfit-auth-service/src/main/java/com/syncfitauthservice/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,4 @@
+package com.syncfitauthservice.dto.request;
+
+public record RefreshTokenRequest(String refreshToken) {
+}

--- a/syncfit-auth-service/src/main/java/com/syncfitauthservice/dto/response/SocialLoginResponse.java
+++ b/syncfit-auth-service/src/main/java/com/syncfitauthservice/dto/response/SocialLoginResponse.java
@@ -1,8 +1,6 @@
 package com.syncfitauthservice.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
-public record SocialLoginResponse(String accessToken, @JsonIgnore String refreshToken) {
+public record SocialLoginResponse(String accessToken, String refreshToken) {
     public static SocialLoginResponse of(String accessToken, String refreshToken) {
         return new SocialLoginResponse(accessToken, refreshToken);
     }

--- a/syncfit-auth-service/src/main/java/com/syncfitauthservice/entity/RefreshToken.java
+++ b/syncfit-auth-service/src/main/java/com/syncfitauthservice/entity/RefreshToken.java
@@ -24,4 +24,9 @@ public class RefreshToken {
         this.token = token;
         this.ttl = ttl;
     }
+
+    public void updateRefreshToken(String newToken, long newTtl){
+        this.token = newToken;
+        this.ttl = newTtl;
+    }
 }

--- a/syncfit-auth-service/src/main/java/com/syncfitauthservice/service/AuthService.java
+++ b/syncfit-auth-service/src/main/java/com/syncfitauthservice/service/AuthService.java
@@ -1,11 +1,16 @@
 package com.syncfitauthservice.service;
 
+import com.syncfitauthservice.dto.AccessTokenDto;
+import com.syncfitauthservice.dto.RefreshTokenDto;
 import com.syncfitauthservice.dto.request.AuthCodeRequest;
+import com.syncfitauthservice.dto.request.RefreshTokenRequest;
 import com.syncfitauthservice.dto.response.IdTokenResponse;
 import com.syncfitauthservice.dto.response.SocialLoginResponse;
 import com.syncfitauthservice.entity.Member;
 import com.syncfitauthservice.entity.OauthInfo;
 import com.syncfitauthservice.repository.MemberRepository;
+import com.syncfitcommonjpa.error.exception.CustomException;
+import com.syncfitcommonjpa.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
@@ -34,6 +39,18 @@ public class AuthService {
         return getLoginResponse(member);
     }
 
+    public SocialLoginResponse refreshToken(RefreshTokenRequest request){
+        RefreshTokenDto oldRefreshTokenDto = jwtTokenService.validateRefreshToken(request.refreshToken());
+
+        if (oldRefreshTokenDto == null){
+            throw new CustomException(ErrorCode.EXPIRED_JWT_TOKEN);
+        }
+
+        RefreshTokenDto newRefreshTokenDto = jwtTokenService.refreshRefreshToken(oldRefreshTokenDto);
+        AccessTokenDto accessTokenDto = jwtTokenService.refreshAccessToken(getMember(newRefreshTokenDto));
+        return new SocialLoginResponse(accessTokenDto.accessTokenValue(), newRefreshTokenDto.refreshTokenValue());
+    }
+
     private SocialLoginResponse getLoginResponse(Member member) {
         String accessToken = jwtTokenService.createAccessToken(member.getId(), member.getRole());
         String refreshToken = jwtTokenService.createRefreshToken(member.getId());
@@ -54,5 +71,10 @@ public class AuthService {
     private OauthInfo extractOauthInfo(OidcUser oidcUser) {
         return OauthInfo.createOauthInfo(
                 oidcUser.getSubject(), oidcUser.getIssuer().toString());
+    }
+
+    private Member getMember(RefreshTokenDto refreshTokenDto){
+        return memberRepository.findById(refreshTokenDto.memberId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/syncfit-auth-service/src/main/java/com/syncfitauthservice/service/JwtTokenService.java
+++ b/syncfit-auth-service/src/main/java/com/syncfitauthservice/service/JwtTokenService.java
@@ -1,16 +1,16 @@
 package com.syncfitauthservice.service;
 
-import com.syncfitauthservice.util.JwtUtil;
 import com.syncfitauthservice.dto.AccessTokenDto;
 import com.syncfitauthservice.dto.RefreshTokenDto;
+import com.syncfitauthservice.entity.Member;
 import com.syncfitauthservice.entity.MemberRole;
 import com.syncfitauthservice.entity.RefreshToken;
 import com.syncfitauthservice.repository.RefreshTokenRepository;
-import io.jsonwebtoken.ExpiredJwtException;
+import com.syncfitauthservice.util.JwtUtil;
+import com.syncfitcommonjpa.error.exception.CustomException;
+import com.syncfitcommonjpa.error.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,25 +19,8 @@ public class JwtTokenService {
     private final JwtUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public AccessTokenDto createAccessTokenDto(Long memberId, MemberRole memberRole) {
-        return jwtUtil.generateAccessTokenDto(memberId, memberRole);
-    }
-
     public String createAccessToken(Long memberId, MemberRole memberRole) {
         return jwtUtil.generateAccessToken(memberId, memberRole);
-    }
-
-    public RefreshTokenDto createRefreshTokenDto(Long memberId) {
-        RefreshTokenDto refreshTokenDto = jwtUtil.generateRefreshTokenDto(memberId);
-        RefreshToken refreshToken =
-                RefreshToken.builder()
-                        .memberId(memberId)
-                        .token(refreshTokenDto.refreshTokenValue())
-                        .ttl(refreshTokenDto.ttl())
-                        .build();
-        refreshTokenRepository.save(refreshToken);
-
-        return refreshTokenDto;
     }
 
     public String createRefreshToken(Long memberId) {
@@ -53,52 +36,24 @@ public class JwtTokenService {
         return token;
     }
 
-    public AccessTokenDto retrieveAccessToken(String accessTokenValue) {
-        try {
-            return jwtUtil.parseAccessToken(accessTokenValue);
-        } catch (Exception e) {
-            return null;
-        }
+    public RefreshTokenDto refreshRefreshToken(RefreshTokenDto oldRefreshTokenDto){
+        RefreshToken refreshToken =
+                refreshTokenRepository
+                        .findById(oldRefreshTokenDto.memberId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.MISSING_JWT_TOKEN));
+
+        RefreshTokenDto refreshTokenDto = jwtUtil.generateRefreshTokenDto(refreshToken.getMemberId());
+        refreshToken.updateRefreshToken(refreshTokenDto.refreshTokenValue(), refreshTokenDto.ttl());
+        refreshTokenRepository.save(refreshToken);
+
+        return refreshTokenDto;
     }
 
-    public RefreshTokenDto retrieveRefreshToken(String refreshTokenValue) {
-        RefreshTokenDto refreshTokenDto = parseRefreshToken(refreshTokenValue);
-
-        if (refreshTokenDto == null) {
-            return null;
-        }
-
-        Optional<RefreshToken> refreshToken = getRefreshToken(refreshTokenDto.memberId());
-
-        if (refreshToken.isPresent() &&
-                refreshTokenDto.refreshTokenValue().equals(refreshToken.get().getToken())) {
-            return refreshTokenDto;
-        }
-
-        return null;
+    public AccessTokenDto refreshAccessToken(Member member){
+        return jwtUtil.generateAccessTokenDto(member.getId(), member.getRole());
     }
 
-    public AccessTokenDto reissueAccessTokenIfExpired(String accessTokenValue) {
-        try {
-            jwtUtil.parseAccessToken(accessTokenValue);
-            return null;
-        } catch (ExpiredJwtException e) {
-            Long memberId = Long.parseLong(e.getClaims().getSubject());
-            MemberRole memberRole = MemberRole.valueOf(e.getClaims().get("role", String.class));
-
-            return createAccessTokenDto(memberId, memberRole);
-        }
-    }
-
-    private RefreshTokenDto parseRefreshToken(String refreshTokenValue) {
-        try {
-            return jwtUtil.parseRefreshToken(refreshTokenValue);
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    private Optional<RefreshToken> getRefreshToken(Long memberId) {
-        return refreshTokenRepository.findById(memberId);
+    public RefreshTokenDto validateRefreshToken(String refreshToken){
+        return jwtUtil.parseRefreshToken(refreshToken);
     }
 }

--- a/syncfit-common-jpa/src/main/java/com/syncfitcommonjpa/error/exception/ErrorCode.java
+++ b/syncfit-common-jpa/src/main/java/com/syncfitcommonjpa/error/exception/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode {
 
     ID_TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "ID 토큰 검증에 실패했습니다."),
     AUTH_NOT_FOUND(HttpStatus.UNAUTHORIZED, "사용자 인증 정보를 찾을 수 없습니다. 올바른 토큰으로 요청해주세요."),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다."),
+    MISSING_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "토큰 정보가 존재하지 않습니다."),
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
 


### PR DESCRIPTION
## 🌱 관련 이슈

- close #33 

---
## 📌 작업 내용 및 특이사항

- 리프레시 토큰 재발급 API를 구현하였습니다.
- 기존 쿠키로 관리되던 리프레시 토큰을 로컬 스토리지에 저장되도록 변경하시면 됩니다.